### PR TITLE
iss11 : Fixed : HTTP requests not getting called when running simulation

### DIFF
--- a/goodload-engine/src/main/java/org/divsgaur/goodload/execution/Simulator.java
+++ b/goodload-engine/src/main/java/org/divsgaur/goodload/execution/Simulator.java
@@ -186,6 +186,7 @@ public class Simulator {
                             actionReport.getSubSteps().add(nestedReport);
                         }
                     } catch (Exception e) {
+                        log.debug("Error occurred in step {}: {}", actionReport.getStepName(), ExceptionUtils.getStackTrace(e));
                         actionReport.setEndedNormally(false);
                     }
                 }));

--- a/goodload-http/src/main/java/org/divsgaur/goodload/http/HttpConfiguration.java
+++ b/goodload-http/src/main/java/org/divsgaur/goodload/http/HttpConfiguration.java
@@ -1,19 +1,14 @@
 package org.divsgaur.goodload.http;
 
-import com.squareup.okhttp.OkHttpClient;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
-import org.springframework.context.support.SimpleThreadScope;
 
 @Configuration
 @Slf4j
 public class HttpConfiguration {
     private static final String THREAD_SCOPE = "threadScope";
 
+    /*
     @Bean
     public static BeanFactoryPostProcessor beanFactoryPostProcessor() {
         return beanFactory ->
@@ -25,4 +20,6 @@ public class HttpConfiguration {
     public OkHttpClient okHttpClient() {
         return new OkHttpClient();
     }
+
+     */
 }

--- a/goodload-http/src/main/java/org/divsgaur/goodload/http/HttpDSL.java
+++ b/goodload-http/src/main/java/org/divsgaur/goodload/http/HttpDSL.java
@@ -5,11 +5,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.RequestBody;
 import lombok.extern.slf4j.Slf4j;
+import org.divsgaur.goodload.dsl.Session;
 
 @Slf4j
 public class HttpDSL {
-    public static HttpRequestBuilder http() {
-        return new HttpRequestBuilder();
+    public static HttpRequestBuilder http(Session session) {
+        return new HttpRequestBuilder(session);
     }
 
     public static RequestBody jsonBody(Object object) {

--- a/goodload-sample/src/main/java/org/divsgaur/goodload/samples/SampleHttpSimulation.java
+++ b/goodload-sample/src/main/java/org/divsgaur/goodload/samples/SampleHttpSimulation.java
@@ -16,7 +16,7 @@ public class SampleHttpSimulation extends Simulation {
     public List<Action> init() {
         Action scenario = scenario("Sample scenario",
                 group("Login",
-                        exec("Get request", (session) -> http()
+                        exec("Get request", (session) -> http(session)
                                 .post("https://www.google.com")
                                 .header("AUTHENTICATION", "")
                                 .header("X-Cache-Control", "")


### PR DESCRIPTION
Fixed: HTTP requests not getting called when running simulation
Instead of running the request, the HttpRequestBuilder.go() was returning another Executable, and hence the execution code was being ignored.

Signed-off-by: Divyansh Shekhar Gaur <26884362+divyanshshekhar@users.noreply.github.com>

Closes #11 