### PR TITLE
Re-interrupt the Simulator and SimulationRunner threads after logging InterruptedException if occurred.

### DIFF
--- a/goodload-engine/src/main/java/org/divsgaur/goodload/config/DefaultExceptionHandlerConfiguration.java
+++ b/goodload-engine/src/main/java/org/divsgaur/goodload/config/DefaultExceptionHandlerConfiguration.java
@@ -35,7 +35,8 @@ public class DefaultExceptionHandlerConfiguration {
             } else if(exception.getCause() instanceof InvalidSimulationConfigFileException) {
                 log.error(exception.getCause().getMessage());
                 return 3;
-            } else if(exception.getCause() instanceof SimulatorInterruptedException) {
+            } else if(exception.getCause() instanceof SimulatorInterruptedException
+                    || exception.getCause() instanceof InterruptedException) {
                 log.error(exception.getCause().getMessage());
                 return 4;
             } else if(exception.getCause() instanceof ClassNotFoundException) {

--- a/goodload-engine/src/main/java/org/divsgaur/goodload/execution/SimulationRunner.java
+++ b/goodload-engine/src/main/java/org/divsgaur/goodload/execution/SimulationRunner.java
@@ -165,6 +165,9 @@ class SimulationRunner implements Callable<SimulationReport> {
 
             return simulationReport;
 
+        } catch(InterruptedException e) {
+            log.error("{} : The runner thread was interrupted. {}", tag, e);
+            Thread.currentThread().interrupt();
         } catch (Exception e) {
             log.error("{} : Unknown exception occurred during execution: ", tag, e);
         }

--- a/goodload-engine/src/main/java/org/divsgaur/goodload/execution/Simulator.java
+++ b/goodload-engine/src/main/java/org/divsgaur/goodload/execution/Simulator.java
@@ -48,7 +48,6 @@ public class Simulator {
      * @param simulationConfig The simulation to execute.
      */
     public AggregateSimulationReport execute(SimulationConfiguration simulationConfig) throws
-            SimulatorInterruptedException,
             ClassNotFoundException,
             NoSuchMethodException,
             InvocationTargetException,
@@ -124,11 +123,12 @@ public class Simulator {
                             goodloadConfigurationProperties.getGracePeriodPercentage(),
                             forceEndAfterDuration),
                     e);
-        }
-        catch (InterruptedException | ExecutionException e) {
-            throw new SimulatorInterruptedException(
-                    String.format("The simulation `%s` was interrupted before completion.",
-                            simulationConfig.getName()), e);
+        } catch (InterruptedException | ExecutionException e) {
+            log.error(String.format(
+                    "The simulation `%s` was interrupted before completion. Nested exception is %s",
+                    simulationConfig.getName(),
+                    e));
+            Thread.currentThread().interrupt();
         }
 
         long simulationEndTime = currentTimestamp();


### PR DESCRIPTION
Signed-off-by: Divyansh Shekhar Gaur <divyanshshekhar@users.noreply.github.com>