### PR TITLE
Initialize GoodloadConfigurationProperties.debugging with default values

### DIFF
--- a/goodload-engine/src/main/java/org/divsgaur/goodload/config/GoodloadConfigurationProperties.java
+++ b/goodload-engine/src/main/java/org/divsgaur/goodload/config/GoodloadConfigurationProperties.java
@@ -49,7 +49,7 @@ public class GoodloadConfigurationProperties {
     /**
      * Properties related to debugging
      */
-    private DebuggingProperties debugging;
+    private DebuggingProperties debugging = new DebuggingProperties();
 
     @Data
     public static class DebuggingProperties {

--- a/goodload-engine/src/main/java/org/divsgaur/goodload/reporting/ReportExporter.java
+++ b/goodload-engine/src/main/java/org/divsgaur/goodload/reporting/ReportExporter.java
@@ -161,5 +161,4 @@ public class ReportExporter {
             throw new UnknownExportFormatException(String.format("The export formats `%s` are not recognized", exportFormats));
         }
     }
-
 }


### PR DESCRIPTION
Initialize GoodloadConfigurationProperties.debugging with default values to prevent null pointer exception when using debugging properties.

Signed-off-by: Divyansh Shekhar Gaur <divyanshshekhar@users.noreply.github.com>

Closes #45 