### PR TITLE
Iss57 : Calculate hits at every second for every step in the simulation

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -4,8 +4,8 @@
     <file url="file://$PROJECT_DIR$/goodload-core/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/goodload-dsl/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/goodload-engine/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/goodload-engine/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/goodload-http/src/main/java" charset="UTF-8" />
-    <file url="file://$PROJECT_DIR$/goodload-reporting/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/goodload-sample/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/goodload-sample/src/main/resources" charset="UTF-8" />
   </component>

--- a/goodload-engine/src/main/java/org/goodload/goodload/reporting/ReportAggregator.java
+++ b/goodload-engine/src/main/java/org/goodload/goodload/reporting/ReportAggregator.java
@@ -52,10 +52,11 @@ public class ReportAggregator {
     private ReportExporter reportExporter;
 
     @Nullable
-    public AggregateSimulationReport aggregate(String simulationName, List<SimulationReport> rawReports, long totalSimulationRunTime) {
+    public AggregateSimulationReport aggregate(String simulationName, List<SimulationReport> rawReports,
+                                               long totalSimulationRunTime) {
         reportExporter.exportRawIfEnabled(simulationName, rawReports);
 
-        if(rawReports == null || rawReports.isEmpty()) {
+        if (rawReports == null || rawReports.isEmpty()) {
             log.info("No reports found. Skipping export.");
             return null;
         }
@@ -65,7 +66,7 @@ public class ReportAggregator {
         var finalSimulationReport = new AggregateSimulationReport(simulationName);
         finalSimulationReport.setTotalTimeInMillis(totalSimulationRunTime);
 
-        for(var scenarioIndex = 0; scenarioIndex < scenarioCount; scenarioIndex++) {
+        for (var scenarioIndex = 0; scenarioIndex < scenarioCount; scenarioIndex++) {
             var transformedRawReports = new ArrayList<ActionReport>();
             /*
              * Raw reports contain n iterations level report in 1 thread level report,
@@ -77,7 +78,7 @@ public class ReportAggregator {
              * The transformed report will have all the reports flattened as list of
              * iterations, and hence will be a list of n*m reports.
              */
-            for(var report: rawReports) {
+            for (var report : rawReports) {
                 transformedRawReports.addAll(report.getScenarios().get(scenarioIndex).getIterations());
             }
             reportExporter.exportTransformedIfEnabled(simulationName, transformedRawReports);
@@ -94,26 +95,30 @@ public class ReportAggregator {
 
     /**
      * Recursively aggregate the raw reports for all the iterations.
+     *
      * @param rawReportList The list of a step where each item in the list
      *                      is report of the same step in different iteration.
      * @return Aggregate report for the step.
      */
     private AggregateActionReport aggregate(List<ActionReport> rawReportList) {
-        if(rawReportList == null || rawReportList.isEmpty()) {
+        if (rawReportList == null || rawReportList.isEmpty()) {
             return new AggregateActionReport(null);
         }
 
         // Number of substeps of current step
-        int subStepCount = Optional.ofNullable(rawReportList.get(0).getSubSteps()).orElse(Collections.emptyList()).size();
+        int subStepCount =
+                Optional.ofNullable(rawReportList.get(0).getSubSteps()).orElse(Collections.emptyList()).size();
 
         var aggregateReportForStep = new AggregateActionReport(rawReportList.get(0).getStepName());
         aggregateReportForStep.setRawReports(rawReportList);
+        aggregateReportForStep.setIterationsStartTimestamp(Long.MAX_VALUE);
+        aggregateReportForStep.setIterationsEndTimestamp(Long.MIN_VALUE);
 
         // Recursively aggregate the sub step reports
         aggregateReportForStep.setSubSteps(new ArrayList<>());
-        for(var subStepIndex = 0; subStepIndex < subStepCount; subStepIndex++) {
+        for (var subStepIndex = 0; subStepIndex < subStepCount; subStepIndex++) {
             List<ActionReport> nestedRawReportList = new ArrayList<>();
-            if(rawReportList.get(0).getSubSteps() != null && !rawReportList.get(0).getSubSteps().isEmpty()) {
+            if (rawReportList.get(0).getSubSteps() != null && !rawReportList.get(0).getSubSteps().isEmpty()) {
                 for (ActionReport report : rawReportList) {
                     nestedRawReportList.add(report
                             .getSubSteps()
@@ -125,25 +130,27 @@ public class ReportAggregator {
         }
 
         // Aggregate the report for the current step.
-        if(!aggregateReportForStep.getRawReports().isEmpty()) {
+        if (!aggregateReportForStep.getRawReports().isEmpty()) {
             checkFailPassCriteria(aggregateReportForStep);
 
-            aggregateReportForStep.setErrorsOccured(
-                    aggregateReportForStep
-                            .getRawReports()
-                            .stream().anyMatch(report -> !report.isEndedNormally())
-            );
-
-            aggregateReportForStep.setAverageTimeInMillis(
-                    aggregateReportForStep
-                            .getRawReports()
-                            .stream()
-                            .map(Report::getTotalTimeInMillis)
-                            .reduce(0L, Long::sum)
-                            / aggregateReportForStep.getRawReports().size()
-            );
+            for (Report rawReport : aggregateReportForStep.getRawReports()) {
+                if (rawReport.getStartTimestampInMillis() < aggregateReportForStep.getIterationsStartTimestamp()) {
+                    aggregateReportForStep.setIterationsStartTimestamp(rawReport.getStartTimestampInMillis());
+                }
+                if (rawReport.getEndTimestampInMillis() > aggregateReportForStep.getIterationsEndTimestamp()) {
+                    aggregateReportForStep.setIterationsEndTimestamp(rawReport.getEndTimestampInMillis());
+                }
+                if (!rawReport.isEndedNormally()) {
+                    aggregateReportForStep.setErrorsOccured(true);
+                }
+                aggregateReportForStep.setTotalTimeInMillis(
+                        aggregateReportForStep.getTotalTimeInMillis() + rawReport.getTotalTimeInMillis());
+            }
 
             aggregateReportForStep.setIterations(aggregateReportForStep.getRawReports().size());
+
+            aggregateReportForStep.setAverageTimeInMillis(
+                    aggregateReportForStep.getTotalTimeInMillis() / aggregateReportForStep.getIterations());
 
             redactRawReports(aggregateReportForStep);
         }
@@ -152,13 +159,15 @@ public class ReportAggregator {
     }
 
     /**
-     * Checks the fail pass criteria for the current report and sets the AggregateActionReport.passed accordingly.
+     * Checks the fail pass criteria for the current report and sets the {@code AggregateActionReport.passed}
+     * accordingly.
+     *
      * @param aggregateReport The aggregate report which is to be checked for fail-pass criteria
      */
     private void checkFailPassCriteria(AggregateActionReport aggregateReport) {
         aggregateReport.setPassed(true);
-        for(var criteria: parsedUserArgs.getFailPassCriteria()) {
-            if(!criteria.matches(aggregateReport.getRawReports())) {
+        for (var criteria : parsedUserArgs.getFailPassCriteria()) {
+            if (!criteria.matches(aggregateReport.getRawReports())) {
                 aggregateReport.setPassed(false);
                 return;
             }
@@ -171,10 +180,11 @@ public class ReportAggregator {
      * If the configuration property {@code goodload.reporting.include-raw-report} is true,
      * then removes only the nested report information from raw reports for current step,
      * otherwise removes the complete raw report information.
+     *
      * @param aggregateReport The aggregate report from which to remove raw report information.
      */
     private void redactRawReports(AggregateActionReport aggregateReport) {
-        if(userArgs.getYamlConfiguration().getReporting().isIncludeRawReport()) {
+        if (userArgs.getYamlConfiguration().getReporting().isIncludeRawReport()) {
             for (var rawReport : aggregateReport.getRawReports()) {
                 rawReport.setSubSteps(null);
             }

--- a/goodload-engine/src/main/java/org/goodload/goodload/reporting/ReportAggregator.java
+++ b/goodload-engine/src/main/java/org/goodload/goodload/reporting/ReportAggregator.java
@@ -49,8 +49,10 @@ public class ReportAggregator {
     private ReportExporter reportExporter;
 
     @Nullable
-    public AggregateSimulationReport aggregate(String simulationName, List<SimulationReport> rawReports,
-                                               long totalSimulationRunTime) {
+    public AggregateSimulationReport aggregate(
+            String simulationName,
+            List<SimulationReport> rawReports,
+            long totalSimulationRunTime) {
         reportExporter.exportRawIfEnabled(simulationName, rawReports);
 
         if (rawReports == null || rawReports.isEmpty()) {
@@ -190,7 +192,7 @@ public class ReportAggregator {
             hitsAtPrevSecond = hitsAtCurrentSecond;
         }
 
-        aggregateReportForStep.setHitsAtSecond(hitsAtSecond);
+        aggregateReportForStep.setHitsAtEverySecond(hitsAtSecond);
     }
 
     /**

--- a/goodload-engine/src/main/java/org/goodload/goodload/reporting/reports/aggregate/AggregateReport.java
+++ b/goodload-engine/src/main/java/org/goodload/goodload/reporting/reports/aggregate/AggregateReport.java
@@ -20,6 +20,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * Report generated after aggregating individual reports generated when simulations are run.
@@ -38,12 +39,32 @@ public abstract class AggregateReport implements Serializable {
     private String stepName;
 
     /**
+     * Timestamp when the first iteration started
+     */
+    private long iterationsStartTimestamp;
+
+    /**
+     * Timestamp when the last iteration ended
+     */
+    private long iterationsEndTimestamp;
+
+    /**
      * The total time (in milliseconds) taken by a step to execute.
+     * Only includes the actual time spent in executing an iteration
+     * and not the time spent in initialization of the steps/iteration
+     * by the engine.
+     * <br>
+     * Note that the initializations/setup you do as part of the step will
+     * be counted towards the aggregate. Only the internal boilerplate
+     * is ignored.
+     * <br>
+     * Hence, the totalTimeInMillis may or may not be equal to
+     * {@code iterationsEndTimestamp - iterationsStartTimestamp}
      */
     private long totalTimeInMillis;
 
     /**
-     * Average time in milliseconds.
+     * Average time in milliseconds. It is equal to totalTimeInMillis / number of iterations.
      */
     private long averageTimeInMillis;
 
@@ -52,6 +73,12 @@ public abstract class AggregateReport implements Serializable {
      * If false, then the execution completed successfully.
      */
     private boolean errorsOccured = false;
+
+    /**
+     * Store number of hits for every second the step was run.
+     * The actual time for nHits at index i = startTimeInMillis / 1000 + i
+     */
+    private List<Float> hitsPerSecond;
 
     protected AggregateReport(String stepName) {
         this.stepName = stepName;

--- a/goodload-engine/src/main/java/org/goodload/goodload/reporting/reports/aggregate/AggregateReport.java
+++ b/goodload-engine/src/main/java/org/goodload/goodload/reporting/reports/aggregate/AggregateReport.java
@@ -76,9 +76,9 @@ public abstract class AggregateReport implements Serializable {
 
     /**
      * Store number of hits for every second the step was run.
-     * The actual time for nHits at index i = startTimeInMillis / 1000 + i
+     * The actual time in second for number of hits at index i = startTimeInMillis / 1000 + i
      */
-    private List<Float> hitsPerSecond;
+    private List<Integer> hitsAtEverySecond;
 
     protected AggregateReport(String stepName) {
         this.stepName = stepName;

--- a/goodload-sample/src/main/java/org/goodload/goodload/samples/SampleHttpSimulation.java
+++ b/goodload-sample/src/main/java/org/goodload/goodload/samples/SampleHttpSimulation.java
@@ -30,7 +30,7 @@ import static org.goodload.goodload.http.HttpDSL.jsonBody;
 public class SampleHttpSimulation implements Simulation {
     @Override
     public List<Action> init() {
-        Action scenario = scenario("Sample scenario",
+        Action scenario = scenario("Sample scenario 1",
                 group("Login",
                         exec("Get request", session -> http(session)
                                 .post("https://www.google.com")
@@ -49,10 +49,10 @@ public class SampleHttpSimulation implements Simulation {
                         exec("Logout: Exec 2", session -> {}),
                         exec("Logout: Exec 3", session -> {}))
         );
-        var scenario2 = scenario("Sample scenario",
+        var scenario2 = scenario("Sample scenario 2",
                 group("Login",
                         exec("Get request", session -> http(session)
-                                .post("https://www.google.com")
+                                .post("https://www.facebook.com")
                                 .header("AUTHENTICATION", "")
                                 .header("X-Cache-Control", "")
                                 .body(jsonBody(new Sample("sample name", "sample descr")))

--- a/goodload-sample/src/main/java/org/goodload/goodload/samples/SampleHttpSimulation.java
+++ b/goodload-sample/src/main/java/org/goodload/goodload/samples/SampleHttpSimulation.java
@@ -30,24 +30,40 @@ import static org.goodload.goodload.http.HttpDSL.jsonBody;
 public class SampleHttpSimulation implements Simulation {
     @Override
     public List<Action> init() {
-        Action scenario = scenario("Sample scenario 1",
+        var scenario1 = scenario("Sample scenario 1",
                 group("Login",
                         exec("Get request", session -> http(session)
-                                .post("https://www.google.com")
+                                .post("https://www.facebook.com")
                                 .header("AUTHENTICATION", "")
                                 .header("X-Cache-Control", "")
                                 .body(jsonBody(new Sample("sample name", "sample descr")))
                                 .go()),
-                        exec("sdf", session -> { }),
+                        exec("sdf", session -> http(session)
+                                .post("https://www.facebook.com")
+                                .header("AUTHENTICATION", "")
+                                .header("X-Cache-Control", "")
+                                .body(jsonBody(new Sample("sample name", "sample descr")))
+                                .go()),
                         check("Login check", session -> true)),
-                /*.check((session) -> {
-                    return ((String) session.get("HEADER-AUTHENTICATION")).equals("401");
-                })*/
-                exec("Execution 1: ", session -> {}),
                 group("Logout",
-                        exec("Logout: Exec 1", session -> {}),
-                        exec("Logout: Exec 2", session -> {}),
-                        exec("Logout: Exec 3", session -> {}))
+                        exec("Logout: Exec 1", session -> http(session)
+                                .post("https://www.facebook.com")
+                                .header("AUTHENTICATION", "")
+                                .header("X-Cache-Control", "")
+                                .body(jsonBody(new Sample("sample name", "sample descr")))
+                                .go()),
+                        exec("Logout: Exec 2", session -> http(session)
+                                .post("https://www.facebook.com")
+                                .header("AUTHENTICATION", "")
+                                .header("X-Cache-Control", "")
+                                .body(jsonBody(new Sample("sample name", "sample descr")))
+                                .go()),
+                        exec("Logout: Exec 3", session -> http(session)
+                                .post("https://www.facebook.com")
+                                .header("AUTHENTICATION", "")
+                                .header("X-Cache-Control", "")
+                                .body(jsonBody(new Sample("sample name", "sample descr")))
+                                .go()))
         );
         var scenario2 = scenario("Sample scenario 2",
                 group("Login",
@@ -57,14 +73,34 @@ public class SampleHttpSimulation implements Simulation {
                                 .header("X-Cache-Control", "")
                                 .body(jsonBody(new Sample("sample name", "sample descr")))
                                 .go()),
-                        exec("sdf", session -> { }),
+                        exec("sdf", session -> http(session)
+                                .post("https://www.facebook.com")
+                                .header("AUTHENTICATION", "")
+                                .header("X-Cache-Control", "")
+                                .body(jsonBody(new Sample("sample name", "sample descr")))
+                                .go()),
                         check("Login check", session -> true)),
                 group("Logout",
-                        exec("Logout: Exec 1", session -> {}),
-                        exec("Logout: Exec 2", session -> {}),
-                        exec("Logout: Exec 3", session -> {}))
+                        exec("Logout: Exec 1", session -> http(session)
+                                .post("https://www.facebook.com")
+                                .header("AUTHENTICATION", "")
+                                .header("X-Cache-Control", "")
+                                .body(jsonBody(new Sample("sample name", "sample descr")))
+                                .go()),
+                        exec("Logout: Exec 2", session -> http(session)
+                                .post("https://www.facebook.com")
+                                .header("AUTHENTICATION", "")
+                                .header("X-Cache-Control", "")
+                                .body(jsonBody(new Sample("sample name", "sample descr")))
+                                .go()),
+                        exec("Logout: Exec 3", session -> http(session)
+                                .post("https://www.facebook.com")
+                                .header("AUTHENTICATION", "")
+                                .header("X-Cache-Control", "")
+                                .body(jsonBody(new Sample("sample name", "sample descr")))
+                                .go()))
         );
 
-        return Arrays.asList(scenario, scenario2);
+        return Arrays.asList(scenario1, scenario2);
     }
 }

--- a/goodload-sample/src/main/resources/config.yaml
+++ b/goodload-sample/src/main/resources/config.yaml
@@ -40,11 +40,10 @@ goodload:
   fail-when:
     - 5% failures
     - atleast 4 failures
-    - atleast x failure
 
   reporting:
     include-raw-report: false
-    export-directory-path: "./goodload-sample/target/"
+    export-directory-path: "target/"
     export-formats:
       - "yaml"
       - "json"

--- a/goodload-sample/src/main/resources/config.yaml
+++ b/goodload-sample/src/main/resources/config.yaml
@@ -29,12 +29,12 @@ goodload:
 
     - name: Sample Http Simulation
       class: org.goodload.goodload.samples.SampleHttpSimulation
-      throughput: 2
-      concurrency: 1
+      throughput: 100
+      concurrency: 100
       hold-for: 10s
       ramp-up: 5s
       ramp-down: 10s
-      iterations: 5
+      iterations: 500
       enabled: true
 
   fail-when:


### PR DESCRIPTION
The number of hits at every second is now included in the aggregate report for better insight into the real time throughput achieved for the simulation.

Also adds two new fields for every step in the simulation-
- `iterationsStartTimestamp` - The timestamp when the first iteration for the step started
- `iterationsEndTimestamp` - The timestamp when the last iteration for the step ended

The hits at every second for each step will now be included as a new list/array field `hitsAtEverySecond` in the report.

The hitsAtEverySecond field shows the total number of iterations (across all threads) executed for every second the simulation was run. The first entry points to time `iterationsStartTimestamp/1000 + 0`, the second entry points to time `iterationsStartTimestamp/1000 + 1`, the third entry points to time `iterationsStartTimestamp/1000 + 2`   and so on.

A sample YAML report is attached. The report has few bugs which have been raised separately as #59 and #58 
[goodload-report-1623864651930.txt](https://github.com/goodload/goodload/files/6664813/goodload-report-1623864651930.txt)


Closes #57 