### PR TITLE
Iss-68 : Fix no main manifest attribute when running engine module's jar

### DIFF
--- a/goodload-engine/pom.xml
+++ b/goodload-engine/pom.xml
@@ -88,4 +88,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Added spring boot maven plugin to engine module.

Closes #68 